### PR TITLE
[Bug]: Fix $PSDefaultParameterValues from Credentials in $PROFILE

### DIFF
--- a/dot_config/powershell/profile.ps1
+++ b/dot_config/powershell/profile.ps1
@@ -201,7 +201,7 @@ if (
     'Connect-PRTGServer:Credential' = $(Get-Secret -Name 'PRTGDefault' -Vault $CredentialVaultName)
     'Connect-VIServer:Credential'   = $(Get-Secret -Name 'VMAdmin' -Vault $CredentialVaultName)
   }.GetEnumerator().Foreach{
-    $PSDefaultCredentials[$PSItem.Name] = $PSItem.Value
+    $PSDefaultParameterValues[$PSItem.Name] = $PSItem.Value
   }
 }
 Remove-Variable CredentialVaultName


### PR DESCRIPTION
Small fix to [Line 204 of profile.ps1](https://github.com/JustinGrote/dotfiles/blob/dd858c05a40321b51a7d63bfc54f14c064339349/dot_config/powershell/profile.ps1#L204):

- [x] Changed `$PSDefaultCredentials` to `$PSDefaultParameterValues`

Before would throw error:

```powershell
InvalidOperation: 
Line |
  10 |          $PSDefaultCredentials[$PSItem.Name] = $PSItem.Value
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot index into a null array.
InvalidOperation:
Line |
  10 |          $PSDefaultCredentials[$PSItem.Name] = $PSItem.Value
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot index into a null array.
```